### PR TITLE
align tags with other infinity metrics

### DIFF
--- a/exporter/cgroup.go
+++ b/exporter/cgroup.go
@@ -58,7 +58,7 @@ func (e *CGroupExporter) Export(c collector.Statsd) bool {
 		cpuStats := e.parseCPUStats(path)
 		log.Printf("cpuStats: %s\n", cpuStats)
 
-		tags = append(tags, collector.CreateTag("service_name", task[1]))
+		tags = append(tags, collector.CreateTag("service", task[1]))
 		tags = append(tags, collector.CreateTag("task_id", task[0]))
 		log.Printf("tags: %s\n", tags)
 


### PR DESCRIPTION
Currently metrics on DD use `service` as tag (called prefix on DD dashbaords). We have to add another variable to all dashboards that want to have the cpu.throttled metrics id we use a different tag for the metrics collected by `cgroup-metrics-reporter`.