### PR TITLE
Removes unnecessary `instance_id` tag

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 	c := collector.NewLoopCollector(
 		config.StatsdCollectorAddress,
 		config.Namesapce,
-		[]string{collector.CreateTag("instance_id", handler.InstanceId)},
+		[]string{},
 	)
 
 	e := exporter.NewCGroupExporter(handler)


### PR DESCRIPTION
Hi! :)

I was looking at your Datadog custom metrics: `pe.cce.infinity.cpu.nr_periods`, `pe.cce.infinity.cpu.nr_throttled` and `pe.cce.infinity.cpu.throttled_time`. After https://github.com/Scout24/cgroup-metrics-reporter/commit/6de4ab0ca0de504d31ac7db491faa577dbe69e3f the number of tags went down from 8917 to 321.

But it's possible to reduce it even further.

I'm proposing the removal of the `instance_id` as a tag.

That same information is already part of every Datadog Custom Metric as `host`, therefore it's not necessary to add it as a tag.

You might need to review your monitors/dashboards to check if you're filtering/aggregating by the `tag` and change it to `host`.